### PR TITLE
fix typo

### DIFF
--- a/exercises/content_headers/solution/solution.js
+++ b/exercises/content_headers/solution/solution.js
@@ -4,7 +4,7 @@ var app = koa();
 
 app.use(function* () {
   this.body = this.request.is('json')
-    ? { message: 'hi' }
+    ? { message: 'hi!' }
     : 'ok';
 });
 


### PR DESCRIPTION
Trivial changes, the **content-header** exercise instructions asking for `{ message: 'hi!' }` but in the solution it uses `{ message: 'hi' }`
