### PR TITLE
Update problem.md to include link to Generator documentation

### DIFF
--- a/exercises/hello_koa/problem.md
+++ b/exercises/hello_koa/problem.md
@@ -42,7 +42,7 @@ app.use(function *() {
 You can read more about ECMAScript 6 generator functions here:
 
 ```
-+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*
+https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*
 ```
 
 A Koa Context(`this` in middlewares) encapsulates node's `request` and `response` objects into a single object which provides many helpful methods for writing web applications and APIs. To learn more about Koa Context, please check the Koa website:


### PR DESCRIPTION
I've added a link to Mozilla's documentation on Generators - It took me a while to realize that function \* is a special syntax and "*" is not meant to be just a placeholder in case developer wants to give the function a name ... 
I wasn't aware of the Generator proposal ... perhaps others aren't aware what it is either
